### PR TITLE
device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ KUP programs limited to start addresses in Slot 1-5, and a maximum size of 40k
 Why aren't we at 1.0, we are missing these features, if anyone wants to
 contribute.
 
-     - Support for device #'s beyond 0
+     - friendlier exe name support (if file doesn't exist, try some extenstions
+     - like .pgz, or .pgx to see if they exist)
+
+     - PATH support
 
      - File Chooser (if no args passed, or file not found this would be
        really nice.  Something like Bitsy Bye for those familiar)

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ KUP programs limited to start addresses in Slot 1-5, and a maximum size of 40k
 Why aren't we at 1.0, we are missing these features, if anyone wants to
 contribute.
 
-     - friendlier exe name support (if file doesn't exist, try some extenstions
-     - like .pgz, or .pgx to see if they exist)
-
      - PATH support
 
      - File Chooser (if no args passed, or file not found this would be

--- a/file.s
+++ b/file.s
@@ -13,6 +13,7 @@ file_bytes_wrote ds 0
 file_bytes_read ds 3
 
 file_to_read ds 1
+file_open_drive ds 1
 		dend
 
 ;
@@ -40,7 +41,8 @@ fopen
 fcreate_open
 		sty kernel_args_file_open_mode
 
-		stz kernel_args_file_open_drive
+		ldy file_open_drive
+		sty kernel_args_file_open_drive
 
 		sta kernel_args_file_open_fname
 		stx kernel_args_file_open_fname+1

--- a/pexec.s
+++ b/pexec.s
@@ -239,13 +239,11 @@ start
 		; OMG there's a device!
 		; if it's valid, maybe it can overide the device 0
 
-		lda <pArg
-		pha
-		clc
-		adc #2
-		sta <pArg 		; fuck you if we need to wrap a page
+		lda (pArg)
 
-		pla
+		inc <pArg
+		inc <pArg 		; fuck you if we need to wrap a page
+
 		sec
 		sbc #'0'
 		cmp #10
@@ -904,7 +902,7 @@ alternate_open
 		lda try_count
 		cmp #5 				; there are 5 extensions
 		bcc ]try
-; we failed 4 more times :-(
+; we failed 5 more times :-(
 		pla
 		rts
 
@@ -957,7 +955,7 @@ alternate_open
 
 ;------------------------------------------------------------------------------
 ; Strings and other includes
-txt_version asc 'Pexec 0.64'
+txt_version asc 'Pexec 0.65'
 		db 13,13,0
 
 txt_press_key db 13

--- a/pexec.s
+++ b/pexec.s
@@ -260,6 +260,8 @@ start
 		ldx #>txt_error_reading
 		jsr TermPUTS
 
+		pla
+
 		jsr TermPrintAH
 		jsr TermCR
 

--- a/pexec.s
+++ b/pexec.s
@@ -117,9 +117,21 @@ start
 		sta	args_buf+1
 
 		lda	kernel_args_extlen
+		beq :zero_args				; validation, this should not be zero, but we'll accept it
 		dec
-		dec
-		sta	args_buflen
+		dec 						; subtract 2 - we get rid of "pexec" from the args list
+		bmi :zero_args              ; this is supposed to be positive
+		bit #1  		
+		bne :zero_args				; this is expected to be even
+
+		sta	args_buflen 			; we've done some reasonable validation here
+		bra :seems_good_args
+
+:zero_args
+		stz args_buflen
+		stz kernel_args_extlen
+
+:seems_good_args
 
 		; Some variable initialization
 		stz progress
@@ -862,6 +874,7 @@ txt_glyph_pexec
 		put file.s
 		put glyphs.s
 		put colors.s
+		put logo.s
 
 ; pad to the end
 		ds $C000-*,$EA


### PR DESCRIPTION
I have added device support into the path name (should work with floppy now)
Auto File Extension support (you no longer have to type in the file extension)
Fixed a bug, where if there was a file error on open the wrong error code would be displayed, and the stack would be corrupted.
0.65
